### PR TITLE
Add personal GPT project with CLI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Personal GPT
+
+This repository contains a lightweight, local-first conversational AI project inspired by ChatGPT. It combines a Hugging Face causal language model with a minimal conversation manager, a command-line interface, and an optional FastAPI server so you can self-host a personal assistant without relying on external APIs.
+
+## Features
+
+- 🧠 **Composable core** – `personal_gpt.PersonalGPT` wraps any Hugging Face causal language model and keeps track of conversation history.
+- 💬 **Interactive CLI** – start chatting from your terminal with configurable sampling parameters.
+- 🌐 **REST API** – deploy the assistant with FastAPI + Uvicorn and integrate it with your own tools.
+- ⚙️ **Configurable** – adjust model name, device (CPU/GPU), temperature, token limits, and more.
+
+## Getting started
+
+### 1. Create and activate a virtual environment (recommended)
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+```
+
+### 2. Install dependencies
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+> ℹ️ The default model is `distilgpt2`, which downloads automatically on first use. You may swap in any other causal language model available on [Hugging Face](https://huggingface.co/models) (for example `microsoft/DialoGPT-medium`).
+
+## Usage
+
+### Chat from the terminal
+
+```bash
+python -m personal_gpt.interface_cli --model distilgpt2 --max-new-tokens 200 --temperature 0.8
+```
+
+During a chat session you can type `exit`, `quit`, or press `Ctrl+C` to stop. Supply `--device cuda` if you have a GPU available.
+
+You can also provide a JSON configuration file with custom generation parameters:
+
+```json
+{
+  "max_new_tokens": 256,
+  "temperature": 0.7,
+  "top_p": 0.85,
+  "repetition_penalty": 1.05,
+  "system_prompt": "You are my friendly personal assistant."
+}
+```
+
+Save it as `config.json` and start the CLI with `--config config.json`.
+
+### Run the REST API
+
+1. Start the server:
+
+   ```bash
+   uvicorn personal_gpt.server:app --reload --port 8000
+   ```
+
+2. Send a request:
+
+   ```bash
+   curl -X POST http://localhost:8000/chat \
+        -H "Content-Type: application/json" \
+        -d '{"message": "Hello, who are you?"}'
+   ```
+
+   Example response:
+
+   ```json
+   {"response": "Hello! I'm a lightweight assistant ready to help."}
+   ```
+
+3. Reset the conversation memory when needed:
+
+   ```bash
+   curl -X POST http://localhost:8000/reset -H "Content-Type: application/json" -d '{"confirm": true}'
+   ```
+
+Open the automatically generated API docs at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+## Project structure
+
+```
+personal_gpt/
+├── __init__.py          # Package exports
+├── config.py            # Model and generation configuration dataclasses
+├── interface_cli.py     # Terminal chat entry point
+├── memory.py            # Conversation history helpers
+├── model.py             # PersonalGPT core wrapper
+└── server.py            # FastAPI server exposing /chat and /reset endpoints
+```
+
+## Customisation tips
+
+- Swap models by editing `ModelConfig.model_name` or passing `--model` on the CLI.
+- Modify `GenerationConfig.system_prompt` to control the assistant's persona.
+- Extend `ConversationMemory` (e.g. for persistence) or implement your own storage backend.
+- Use the FastAPI server as a base for building automations, Slack bots, or GUI front-ends.
+
+## Disclaimer
+
+This project is intentionally lightweight and does not implement advanced safety features, moderation, or retrieval augmentation. For serious production deployments you should evaluate additional safeguards and monitor model outputs carefully.

--- a/personal_gpt/__init__.py
+++ b/personal_gpt/__init__.py
@@ -1,0 +1,12 @@
+"""Personal GPT package for building lightweight local conversational agents."""
+
+from .config import GenerationConfig, ModelConfig
+from .memory import ConversationMemory
+from .model import PersonalGPT
+
+__all__ = [
+    "GenerationConfig",
+    "ModelConfig",
+    "ConversationMemory",
+    "PersonalGPT",
+]

--- a/personal_gpt/config.py
+++ b/personal_gpt/config.py
@@ -1,0 +1,36 @@
+"""Configuration dataclasses for the Personal GPT project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ModelConfig:
+    """Configuration controlling how the base language model is loaded."""
+
+    model_name: str = "distilgpt2"
+    """Name or path of the Hugging Face model to load."""
+
+    device: Optional[str] = None
+    """Target device ("cpu" or "cuda"). ``None`` lets PyTorch decide automatically."""
+
+    trust_remote_code: bool = False
+    """Whether to allow execution of custom model code provided by the repository."""
+
+
+@dataclass
+class GenerationConfig:
+    """Parameters that shape the style of generated responses."""
+
+    max_new_tokens: int = 256
+    temperature: float = 0.7
+    top_p: float = 0.9
+    repetition_penalty: float = 1.0
+    stop_sequences: list[str] = field(default_factory=lambda: ["User:", "Assistant:"])
+    system_prompt: str = (
+        "You are a helpful, concise personal assistant."
+        " Respond directly to the user's request using the information"
+        " provided in the conversation."
+    )

--- a/personal_gpt/interface_cli.py
+++ b/personal_gpt/interface_cli.py
@@ -1,0 +1,77 @@
+"""Command line chat interface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .config import GenerationConfig, ModelConfig
+from .model import PersonalGPT
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Chat with a local Personal GPT model")
+    parser.add_argument("--model", default="distilgpt2", help="Model name or path to load")
+    parser.add_argument("--device", default=None, help="Device to run on (cpu or cuda)")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Optional path to a JSON file containing generation parameters",
+    )
+    parser.add_argument(
+        "--max-new-tokens", type=int, default=None, help="Maximum number of generated tokens"
+    )
+    parser.add_argument("--temperature", type=float, default=None, help="Sampling temperature")
+    parser.add_argument("--top-p", type=float, default=None, help="Nucleus sampling parameter")
+    parser.add_argument(
+        "--repetition-penalty", type=float, default=None, help="Penalty for repeated tokens"
+    )
+    return parser.parse_args()
+
+
+def load_generation_config(args: argparse.Namespace) -> GenerationConfig:
+    config = GenerationConfig()
+    if args.config and args.config.exists():
+        data: Dict[str, Any] = json.loads(args.config.read_text())
+        config = GenerationConfig(**data)
+
+    if args.max_new_tokens is not None:
+        config.max_new_tokens = args.max_new_tokens
+    if args.temperature is not None:
+        config.temperature = args.temperature
+    if args.top_p is not None:
+        config.top_p = args.top_p
+    if args.repetition_penalty is not None:
+        config.repetition_penalty = args.repetition_penalty
+
+    return config
+
+
+def run_cli() -> None:
+    args = parse_args()
+    model_config = ModelConfig(model_name=args.model, device=args.device)
+    generation_config = load_generation_config(args)
+
+    assistant = PersonalGPT(model_config=model_config, generation_config=generation_config)
+
+    print("Personal GPT - type 'exit' or Ctrl+C to quit.\n")
+    while True:
+        try:
+            user_input = input("You: ")
+        except (KeyboardInterrupt, EOFError):
+            print("\nGoodbye!")
+            break
+
+        if user_input.strip().lower() in {"exit", "quit", "bye"}:
+            print("Goodbye!")
+            break
+
+        response = assistant.chat(user_input)
+        print(f"Assistant: {response}\n")
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/personal_gpt/memory.py
+++ b/personal_gpt/memory.py
@@ -1,0 +1,37 @@
+"""Conversation memory utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+
+@dataclass
+class Message:
+    """Represents a single chat message."""
+
+    role: str
+    content: str
+
+    def format(self) -> str:
+        return f"{self.role}: {self.content.strip()}"
+
+
+class ConversationMemory:
+    """Simple in-memory storage for conversation history."""
+
+    def __init__(self, messages: Iterable[Message] | None = None) -> None:
+        self._messages: List[Message] = list(messages) if messages else []
+
+    def add(self, role: str, content: str) -> None:
+        self._messages.append(Message(role=role, content=content))
+
+    def clear(self) -> None:
+        self._messages.clear()
+
+    @property
+    def messages(self) -> Sequence[Message]:
+        return tuple(self._messages)
+
+    def formatted_history(self) -> str:
+        return "\n".join(message.format() for message in self._messages)

--- a/personal_gpt/model.py
+++ b/personal_gpt/model.py
@@ -1,0 +1,98 @@
+"""Model wrapper used to generate chat completions."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from .config import GenerationConfig, ModelConfig
+from .memory import ConversationMemory
+
+
+class PersonalGPT:
+    """High level helper that mimics a lightweight ChatGPT-style interface."""
+
+    def __init__(
+        self,
+        model_config: Optional[ModelConfig] = None,
+        generation_config: Optional[GenerationConfig] = None,
+        memory: Optional[ConversationMemory] = None,
+    ) -> None:
+        self.model_config = model_config or ModelConfig()
+        self.generation_config = generation_config or GenerationConfig()
+        self.memory = memory or ConversationMemory()
+
+        self.device = self._resolve_device(self.model_config.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_config.model_name,
+            trust_remote_code=self.model_config.trust_remote_code,
+        )
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_config.model_name,
+            trust_remote_code=self.model_config.trust_remote_code,
+        ).to(self.device)
+
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        self.eos_token_id = self.tokenizer.eos_token_id
+
+    @staticmethod
+    def _resolve_device(user_choice: Optional[str]) -> torch.device:
+        if user_choice:
+            return torch.device(user_choice)
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        return torch.device("cpu")
+
+    def build_prompt(self, user_message: str) -> str:
+        parts: list[str] = []
+        system_prompt = self.generation_config.system_prompt.strip()
+        if system_prompt:
+            parts.append(f"System: {system_prompt}")
+
+        history = self.memory.formatted_history().strip()
+        if history:
+            parts.append(history)
+
+        parts.append(f"User: {user_message.strip()}")
+        parts.append("Assistant:")
+        return "\n".join(parts)
+
+    def _apply_stop_sequences(self, text: str) -> str:
+        for stop in self.generation_config.stop_sequences:
+            if not stop:
+                continue
+            idx = text.find(stop)
+            if idx != -1:
+                text = text[:idx]
+        return text.strip()
+
+    def generate(self, user_message: str) -> str:
+        prompt = self.build_prompt(user_message)
+        encoded = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+
+        with torch.no_grad():
+            output = self.model.generate(
+                **encoded,
+                max_new_tokens=self.generation_config.max_new_tokens,
+                temperature=self.generation_config.temperature,
+                top_p=self.generation_config.top_p,
+                repetition_penalty=self.generation_config.repetition_penalty,
+                do_sample=True,
+                pad_token_id=self.eos_token_id,
+            )
+
+        generated_tokens = output[0][encoded["input_ids"].shape[-1] :]
+        raw_text = self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
+        return self._apply_stop_sequences(raw_text)
+
+    def chat(self, user_message: str) -> str:
+        self.memory.add("User", user_message)
+        assistant_reply = self.generate(user_message)
+        self.memory.add("Assistant", assistant_reply)
+        return assistant_reply
+
+    def reset(self) -> None:
+        self.memory.clear()

--- a/personal_gpt/server.py
+++ b/personal_gpt/server.py
@@ -1,0 +1,55 @@
+"""FastAPI server that exposes a lightweight chat completion endpoint."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .config import GenerationConfig, ModelConfig
+from .model import PersonalGPT
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+class ChatResponse(BaseModel):
+    response: str
+
+
+class ResetRequest(BaseModel):
+    confirm: bool = True
+
+
+app = FastAPI(title="Personal GPT", version="1.0.0")
+
+
+@lru_cache(maxsize=1)
+def get_assistant(
+    model_name: str = "distilgpt2",
+    device: Optional[str] = None,
+) -> PersonalGPT:
+    model_config = ModelConfig(model_name=model_name, device=device)
+    generation_config = GenerationConfig()
+    return PersonalGPT(model_config=model_config, generation_config=generation_config)
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(request: ChatRequest) -> ChatResponse:
+    if not request.message.strip():
+        raise HTTPException(status_code=400, detail="Message must not be empty")
+    assistant = get_assistant()
+    reply = assistant.chat(request.message)
+    return ChatResponse(response=reply)
+
+
+@app.post("/reset")
+async def reset_conversation(request: ResetRequest) -> dict[str, str]:
+    if not request.confirm:
+        raise HTTPException(status_code=400, detail="Confirmation required to reset")
+    assistant = get_assistant()
+    assistant.reset()
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+torch>=2.0.0
+transformers>=4.37.0
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0


### PR DESCRIPTION
## Summary
- add a reusable `personal_gpt` package with configuration, conversation memory, and model wrapper
- create a command-line interface and FastAPI server for interacting with the assistant
- document installation and usage instructions and add runtime dependencies

## Testing
- python -m compileall personal_gpt

------
https://chatgpt.com/codex/tasks/task_e_68ce56757f148321808e6883d11d0a9a